### PR TITLE
change how snippet table data is sourced

### DIFF
--- a/src/lib/snippets.ts
+++ b/src/lib/snippets.ts
@@ -1,0 +1,20 @@
+export interface snippetType {
+  title: string;
+  date: string;
+  description: string;
+  src: string;
+}
+
+// for now, grab a manually-curated list of snippets; in the future, find a way to
+// dynamically search all post content for blocks of code that indicate a snippet.
+export const getAllSnippets = (): snippetType[] => {
+  const snippets: snippetType[] = [
+    {
+      title: "NamedTuple Class",
+      date: "2022-01-01",
+      description: "Using a NamedTuple to create a container class",
+      src: "/python-container-classes#namedtuple",
+    },
+  ];
+  return snippets;
+};

--- a/src/posts/20220101-python-container-classes.md
+++ b/src/posts/20220101-python-container-classes.md
@@ -9,17 +9,19 @@ status: published
 
 I often want to create objects that hold several related pieces of data together in the same place - like a `Book` object that has an `author`, `title`, etc. Python offers several methods to do this, but it's not always clear which one to use. I'll show different patterns that I use and discuss the advantages and disadvantages of each.
 
-| Name               | Description                                                      |
-| ------------------ | ---------------------------------------------------------------- |
-| Vanilla Class)     | A plain Python class                                             |
-| Dictionary         | A plain Python dictionary                                        |
-| (Typed) Dictionary | A Python dictionary with typed fields                            |
-| Simple Namespace   | A Python namespace object                                        |
-| NamedTuple         | A tuple with names, from the `collections` module                |
-| Dataclass          | A container class from the `dataclasses` module                  |
-| `attrs` Class      | The only non-standard-library solution, from the `attrs` library |
+I call these container classes because they're mostly used to hold information.
 
-# Vanilla Class
+| Name                                       | Description                                                      |
+| ------------------------------------------ | ---------------------------------------------------------------- |
+| <a href="#vanilla-class">Vanilla Class</a> | A plain Python class                                             |
+| Dictionary                                 | A plain Python dictionary                                        |
+| (Typed) Dictionary                         | A Python dictionary plus a `TypedDict` schema                    |
+| Simple Namespace                           | A Python namespace object                                        |
+| <a href="#namedtuple">NamedTuple</a>       | A tuple with names, from the `collections` module                |
+| Dataclass                                  | A container class from the `dataclasses` module                  |
+| `attrs` Class                              | The only non-standard-library solution, from the `attrs` library |
+
+<h1 id="vanilla-class">Vanilla Class</h1>
 
 ```python
 class Book:
@@ -73,7 +75,7 @@ brothers_karamazov: Book = {
 
 # SimpleNamespace
 
-# NamedTuple
+<h1 id="namedtuple">NamedTuple</h1>
 
 ```python
 from typing import NamedTuple
@@ -86,6 +88,14 @@ class Book(NamedTuple):
     publication_year: int
     isbn_10: Optional[str]
     isbn_13: Optional[str]
+
+brothers_karamazov = Book(
+    author="Fyodor Dostoevsky",
+    title="The Brothers Karamazov",
+    publication_year=1880,
+    isbn_10="0374528373",
+    isbn_13="978-0374528379",
+)
 ```
 
 # Dataclass
@@ -102,4 +112,14 @@ class Book:
     publication_year: int
     isbn_10: Optional[str]
     isbn_13: Optional[str]
+
+brothers_karamazov = Book(
+    author="Fyodor Dostoevsky",
+    title="The Brothers Karamazov",
+    publication_year=1880,
+    isbn_10="0374528373",
+    isbn_13="978-0374528379",
+)
 ```
+
+# Attrs Class

--- a/src/posts/20220101-python-container-classes.md
+++ b/src/posts/20220101-python-container-classes.md
@@ -11,15 +11,15 @@ I often want to create objects that hold several related pieces of data together
 
 I call these container classes because they're mostly used to hold information.
 
-| Name                                       | Description                                                      |
-| ------------------------------------------ | ---------------------------------------------------------------- |
-| <a href="#vanilla-class">Vanilla Class</a> | A plain Python class                                             |
-| Dictionary                                 | A plain Python dictionary                                        |
-| (Typed) Dictionary                         | A Python dictionary plus a `TypedDict` schema                    |
-| Simple Namespace                           | A Python namespace object                                        |
-| <a href="#namedtuple">NamedTuple</a>       | A tuple with names, from the `collections` module                |
-| Dataclass                                  | A container class from the `dataclasses` module                  |
-| `attrs` Class                              | The only non-standard-library solution, from the `attrs` library |
+| Name                                             | Description                                                      |
+| ------------------------------------------------ | ---------------------------------------------------------------- |
+| <a href="#vanilla-class">Vanilla Class</a>       | A plain Python class                                             |
+| <a href="#dictionary">Dictionary</a>             | A plain Python dictionary                                        |
+| <a href="#typed-dictionary">Typed Dictionary</a> | A Python dictionary plus a `TypedDict` schema                    |
+| <a href="#simplenamespace">SimpleNamespace</a>   | A Python namespace object                                        |
+| <a href="#namedtuple">NamedTuple</a>             | A tuple with names, from the `collections` module                |
+| <a href="#dataclass">Dataclass</a>               | A container class from the `dataclasses` module                  |
+| <a href="#attrs-class">`attrs` Class</a>         | The only non-standard-library solution, from the `attrs` library |
 
 <h1 id="vanilla-class">Vanilla Class</h1>
 
@@ -48,9 +48,22 @@ brothers_karamazov = Book(
     isbn_10="0374528373",
     isbn_13="978-0374528379",
 )
+
 ```
 
-# (Typed) Dictionary
+<h1 id="dictionary">Dictionary</h1>
+
+```python
+brothers_karamazov: Book = {
+    "author": "Fyodor Dostoevsky",
+    "title": "The Brothers Karamazov",
+    "publication_year": 1880,
+    "isbn_10": "0374528373",
+    "isbn_13": "978-0374528379",
+}
+```
+
+<h1 id="typed-dictionary">Typed Dictionary</h1>
 
 ```python
 from typing import TypedDict
@@ -73,7 +86,7 @@ brothers_karamazov: Book = {
 }
 ```
 
-# SimpleNamespace
+<h1 id="simplenamespace">SimpleNamespace</h1>
 
 <h1 id="namedtuple">NamedTuple</h1>
 
@@ -98,7 +111,7 @@ brothers_karamazov = Book(
 )
 ```
 
-# Dataclass
+<h1 id="dataclass">Dataclass</h1>
 
 ```python
 from dataclasses import dataclass
@@ -122,4 +135,4 @@ brothers_karamazov = Book(
 )
 ```
 
-# Attrs Class
+<h1 id="attrs-class">Attrs Class</h1>

--- a/src/routes/snippets.json.ts
+++ b/src/routes/snippets.json.ts
@@ -1,0 +1,8 @@
+import type { RequestHandler } from "@sveltejs/kit";
+import { getAllSnippets } from "$lib/snippets";
+
+export const get: RequestHandler = (): { body: string } => {
+  const snippets = getAllSnippets();
+  const body = JSON.stringify(snippets);
+  return { body };
+};

--- a/src/routes/snippets.svelte
+++ b/src/routes/snippets.svelte
@@ -13,7 +13,6 @@
 
 <script lang="ts">
   export let snippets: snippetType[];
-  console.log(snippets);
 </script>
 
 <svelte:head>

--- a/src/routes/snippets.svelte
+++ b/src/routes/snippets.svelte
@@ -1,19 +1,18 @@
 <script context="module" lang="ts">
   import type { Load } from "@sveltejs/kit";
-  import type { postType } from "$lib/posts";
+  import type { snippetType } from "$lib/snippets";
   import { base } from "$app/paths";
 
   export const load: Load = async ({
     fetch,
-  }): Promise<{ props: { snippets: postType[] } }> => {
-    const posts = await fetch(`${base}/index.json`).then((r) => r.json());
-    const snippets = await posts.filter((post) => post.tags.includes("snippet"));
+  }): Promise<{ props: { snippets: snippetType[] } }> => {
+    const snippets = await fetch(`${base}/snippets.json`).then((r) => r.json());
     return { props: { snippets } };
   };
 </script>
 
 <script lang="ts">
-  export let snippets: postType[];
+  export let snippets: snippetType[];
   console.log(snippets);
 </script>
 
@@ -34,8 +33,8 @@
   <tbody>
     {#each snippets as snippet}
       <tr>
-        <td><a href="/{snippet.slug}">{snippet.title}</a></td>
-        <td>{snippet.excerpt}</td>
+        <td><a href={snippet.src}>{snippet.title}</a></td>
+        <td>{snippet.description}</td>
         <td>{snippet.date}</td>
       </tr>
     {/each}


### PR DESCRIPTION
Create a list of snippet objects that becomes the source data for the snippets page. Eventually I can implement a better way of automatically scanning all posts for snippet data, but starting manually for now. Makes progress on #12.